### PR TITLE
JAPACCOE-2749 - To use cloud-store-sdk_2.12:1.4.5

### DIFF
--- a/credential-generator/certificate-processor/pom.xml
+++ b/credential-generator/certificate-processor/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.sunbird</groupId>
             <artifactId>cloud-store-sdk_${scala.version}</artifactId>
-            <version>1.2.5</version>
+            <version>1.4.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.sunbird</groupId>
             <artifactId>cloud-store-sdk_2.12</artifactId>
-            <version>1.4.4</version>
+            <version>1.4.5</version>
             <exclusions>
                 <exclusion>
                     <artifactId>log4j</artifactId>

--- a/jobs-distribution/Dockerfile
+++ b/jobs-distribution/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get install -y imagemagick
 COPY target/jobs-distribution-1.0.tar.gz /tmp
 USER flink
 RUN tar -xvf /tmp/jobs-distribution-1.0.tar.gz -C $FLINK_HOME/lib/
+RUN cp $FLINK_HOME/opt/flink-s3-fs-presto-1.13.5.jar $FLINK_HOME/lib/aaa_flink-s3-fs-presto-1.13.5.jar
 USER root
 RUN rm -f /tmp/jobs-distribution-1.0.tar.gz
 USER flink


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

The main intention of this change is to use cloud-store-sdk_2.12 with version 1.4.5. This is a version which has oracle oss connectivity.

The other change we did was to copy the presto jar in the lib directory. Did a hack to prefix by aaa_ , so that the presto jars ( flink-s3-fs-presto-1.13.5.jar ) gets loaded before flink-s3-fs-hadoop-1.13.5.jar in the classpath

`RUN cp $FLINK_HOME/opt/flink-s3-fs-presto-1.13.5.jar $FLINK_HOME/lib/aaa_flink-s3-fs-presto-1.13.5.jar`


- [X] Deployed the kp flinkjobs
